### PR TITLE
Fix for empty survey

### DIFF
--- a/forms/helpers.py
+++ b/forms/helpers.py
@@ -68,6 +68,9 @@ def check_previous_answer(user_id):
 
 # Turn string of subjects as a list of dicts with the complete info about every subject
 def get_subjects_list_of_dicts(string_of_subjects, degree_id, group_id):
+    subjects_list_of_dicts =  []    
+    if string_of_subjects is None: return subjects_list_of_dicts
+
     subjects_list = [subject.replace(' ', '') for subject in string_of_subjects.split(',')
                      if 'Tutoria' not in subject and 'Centre' not in subject]
     
@@ -83,7 +86,7 @@ def get_subjects_list_of_dicts(string_of_subjects, degree_id, group_id):
                                     ) T WHERE group_id = %s
                                     ORDER BY code, name;
                                   """
-    subjects_list_of_dicts =  []
+    
     for subject in subjects_list:
         cursor = connections['default'].cursor()
         cursor.execute(sql_get_subject_information, (group_id, subject, degree_id, subject, degree_id, group_id, group_id,))
@@ -249,6 +252,10 @@ def log_error(error, data='no data'):
     elif error == 'unidentified_user':
         with open(WRONG_ACCESS_ERROR_LOG, 'a') as error_log:
             error_log.write("%s, %s, %s" % (str(timezone.now()), 'unidentified_user', data) + "\n")
+
+    elif error == 'empty_survey':
+        with open(WRONG_ACCESS_ERROR_LOG, 'a') as error_log:
+            error_log.write("%s, %s, %s" % (str(timezone.now()), 'empty_survey', data) + "\n")
 
     # Database save error
     else:

--- a/forms/urls.py
+++ b/forms/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('subject_form/', views.subject_evaluation, name='subject_evaluation'),
     path('recorded_response/', views.recorded_response, name='recorded_response'),
     path('unidentified_user/', views.unidentified_user, name='unidentified_user'),
+    path('empty_survey/', views.empty_survey, name='empty_survey'),
     path('wrong_email<str:user_email>/', views.wrong_email, name='wrong_email'),
     path('not_enrolled<str:user_email>/', views.not_enrolled, name='not_enrolled'),
     path('duplicated_answer<str:user_email>/', views.duplicated_answer, name='duplicated_answer'),

--- a/forms/views.py
+++ b/forms/views.py
@@ -56,6 +56,9 @@ def subject_evaluation(request):
         ue = request.session['user_evaluation']
         user_subjects_info = get_subjects_list_of_dicts(ue['subjects'], ue['degree_id'], ue['group_id'])
 
+        if len(user_subjects_info) == 0: 
+            return HttpResponseRedirect(reverse('forms:empty_survey'))
+
         SubjectsFormset = formset_factory(EvaluateSubjectCF, extra=len(user_subjects_info))
         formset = SubjectsFormset(request.POST or None)
         
@@ -169,3 +172,7 @@ def duplicated_answer(request, user_email):
 def unidentified_user(request):
     log_error('unidentified_user')
     return render(request, 'errors/unidentified_user.html')
+
+def empty_survey(request):
+    log_error('empty_survey')
+    return render(request, 'errors/empty_survey.html')

--- a/templates/errors/empty_survey.html
+++ b/templates/errors/empty_survey.html
@@ -1,0 +1,27 @@
+{% load socialaccount %}
+{% load static %}
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}" />
+
+</head>
+<body>
+  <div class="container text-dark mt-5">
+    <div class="row justify-content-md-center">
+      <div class="col-md-5 bg-grey p-3">
+        <h1 style="text-align: center;">ENQUESTA BUIDA</h1>
+            <p style="text-align: center;">Aquest usuari no té cap cap element (tutoria, centre, assignatura o mòdul professional) d'enquesta assignat.</p>
+            <br>
+            <p style="text-align: center;">Fes clic per iniciar sessió amb un altre compte.</p>
+            <a href="{% provider_login_url 'google' %}" class="btn btn btn-warning btn-lg btn-block" role="button" aria-pressed="true">Nou inici de sessió</a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
When a user has no survey data attached (no relation between the user and subjects has been provided) a more accurate error message will be displayed, instead of the wrong login one. 